### PR TITLE
Add in-place methods

### DIFF
--- a/src/permutation.rs
+++ b/src/permutation.rs
@@ -500,12 +500,8 @@ impl Permutation {
     /// This method borrows `self` mutably to avoid allocations, but the permutation
     /// will be unchanged after it returns.
     ///
-    /// Note that unlike the other `apply_*` methods, this method *requires* the permutation
-    /// to be normalized in the opposite direction, or it will panic.
-    ///
     /// # Panics
     ///
-    /// If the permutation is not normalized for backward application.
     /// If `slice.len() != self.len()`.
     /// If `slice.len()` > isize::max_value(), due to implementation reasons.
     ///
@@ -528,7 +524,7 @@ impl Permutation {
 
     /// Apply the inverse of a permutation to a slice of elements
     ///
-    /// Given a slice of elements, this will permute the elements in placeaccording
+    /// Given a slice of elements, this will permute the elements in place according
     /// to the inverse of this permutation.
     /// This is equivalent to "undoing" the permutation.
     ///
@@ -537,7 +533,6 @@ impl Permutation {
     ///
     /// # Panics
     ///
-    /// If the permutation is not normalized for forward application.
     /// If `slice.len() != self.len()`.
     /// If `slice.len()` > isize::max_value(), due to implementation reasons.
     ///

--- a/src/permutation.rs
+++ b/src/permutation.rs
@@ -17,12 +17,11 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 use std;
 use std::cmp::Ordering;
 use std::ops::Deref;
 
-#[derive(Clone,Debug)]
+#[derive(Clone, Debug)]
 pub struct Permutation {
     inv: bool,
     indices: Vec<usize>,
@@ -55,19 +54,17 @@ impl<'a, 'b> std::ops::Mul<&'b Permutation> for &'a Permutation {
     /// # use permutation::Permutation;
     /// let p1 = Permutation::from_vec(vec![1, 0, 2]);
     /// let p2 = Permutation::from_vec(vec![0, 2, 1]);
-    /// assert!(&p1 * &p2 == Permutation::from_vec(vec![2,0,1]));
+    /// assert_eq!(&p1 * &p2, Permutation::from_vec(vec![2,0,1]));
     /// ```
 
     fn mul(self, rhs: &'b Permutation) -> Self::Output {
         match (self.inv, rhs.inv) {
             (_, false) => Permutation::from_vec(self.apply_slice(&rhs.indices[..])),
             (false, true) => return self * &(rhs * &Permutation::one(self.len())),
-            (true, true) => {
-                Permutation {
-                    inv: true,
-                    indices: rhs.apply_inv_slice(&self.indices[..]),
-                }
-            }
+            (true, true) => Permutation {
+                inv: true,
+                indices: rhs.apply_inv_slice(&self.indices[..]),
+            },
         }
     }
 }
@@ -85,7 +82,7 @@ impl Permutation {
     /// # use permutation::Permutation;
     /// let vec = vec!['a','b','c','d'];
     /// let permutation = Permutation::from_vec(vec![0,2,3,1]);
-    /// assert!(permutation.apply_slice(&vec[..]) == vec!['a','c','d','b']);
+    /// assert_eq!(permutation.apply_slice(&vec[..]), vec!['a','c','d','b']);
     /// ```
     pub fn from_vec(vec: Vec<usize>) -> Permutation {
         let result = Permutation {
@@ -96,6 +93,110 @@ impl Permutation {
         debug_assert!(result.valid());
         return result;
     }
+    /// Computes the permutation that would sort a given slice.
+    ///
+    /// This calculates the permutation that if it were applied to the slice,
+    /// would put the elements in sorted order.
+    ///
+    /// # Panics
+    ///
+    /// If self.len() != vec.len()
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use permutation::Permutation;
+    /// let mut vec = vec!['z','w','h','a','s','j'];
+    /// let mut permutation = permutation::Permutation::one(vec.len());
+    /// permutation.sort(&vec[..]);
+    /// let permuted = permutation.apply_slice(&vec[..]);
+    /// vec.sort();
+    /// assert_eq!(vec, permuted);
+    /// ```
+    ///
+    /// You can also use it to sort multiple arrays based on the ordering of one.
+    ///
+    /// ```
+    /// let names = vec!["Bob", "Steve", "Jane"];
+    /// let salary = vec![10, 5, 15];
+    /// let mut permutation = permutation::Permutation::one(salary.len());
+    /// permutation.sort(&salary[..]);
+    /// let ordered_names = permutation.apply_slice(&names[..]);
+    /// let ordered_salaries = permutation.apply_slice(&salary[..]);
+    /// assert_eq!(ordered_names, vec!["Steve", "Bob", "Jane"]);
+    /// assert_eq!(ordered_salaries, vec![5, 10, 15]);
+    /// ```
+    pub fn sort<T, D>(&mut self, vec: D)
+    where
+        T: Ord,
+        D: Deref<Target = [T]>,
+    {
+        assert_eq!(self.len(), vec.len());
+        //We use the reverse permutation form, because its more efficient for applying to indices.
+        self.indices.sort_by_key(|&i| &vec[i]);
+    }
+
+    /// Computes the permutation that would sort a given slice by a comparator.
+    ///
+    /// This is the same as `permutation::sort()` except that it allows you to specify
+    /// the comparator to use when sorting similar to `std::slice.sort_by()`
+    ///
+    /// # Panics
+    ///
+    /// If self.len() != vec.len()
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use permutation::Permutation;
+    /// let mut vec = vec!['z','w','h','a','s','j'];
+    /// let mut permutation = permutation::Permutation::one(vec.len());
+    /// permutation.sort_by(&vec[..], |a, b| b.cmp(a));
+    /// let permuted = permutation.apply_slice(&vec[..]);
+    /// vec.sort_by(|a,b| b.cmp(a));
+    /// assert_eq!(vec, permuted);
+    /// ```
+    pub fn sort_by<T, D, F>(&mut self, vec: D, mut compare: F)
+    where
+        T: Ord,
+        D: Deref<Target = [T]>,
+        F: FnMut(&T, &T) -> Ordering,
+    {
+        assert_eq!(self.indices.len(), vec.len());
+        //We use the reverse permutation form, because its more efficient for applying to indices.
+        self.indices.sort_by(|&i, &j| compare(&vec[i], &vec[j]));
+    }
+
+    /// Computes the permutation that would sort a given slice by a key function.
+    ///
+    /// This is the same as `permutation::sort()` except that it allows you to specify
+    /// the key function simliar to `std::slice.sort_by_key()`
+    ///
+    /// # Panics
+    ///
+    /// If self.len() != vec.len()
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use permutation::Permutation;
+    /// let mut vec = vec![2, 4, 6, 8, 10, 11];
+    /// let mut permutation = permutation::Permutation::one(vec.len());
+    /// permutation.sort_by_key(&vec[..], |a| a % 3);
+    /// let permuted = permutation.apply_slice(&vec[..]);
+    /// vec.sort_by_key(|a| a % 3);
+    /// assert_eq!(vec, permuted);
+    /// ```
+    pub fn sort_by_key<T, D, B, F>(&mut self, vec: D, mut f: F)
+    where
+        B: Ord,
+        D: Deref<Target = [T]>,
+        F: FnMut(&T) -> B,
+    {
+        assert_eq!(self.indices.len(), vec.len());
+        //We use the reverse permutation form, because its more efficient for applying to indices.
+        self.indices.sort_by_key(|&i| f(&vec[i]));
+    }
     /// Return the identity permutation of size N.
     ///
     /// This returns the identity permutation of N elements.
@@ -105,7 +206,7 @@ impl Permutation {
     /// # use permutation::Permutation;
     /// let vec = vec!['a','b','c','d'];
     /// let permutation = Permutation::one(4);
-    /// assert!(permutation.apply_slice(&vec[..]) == vec!['a','b','c','d']);
+    /// assert_eq!(permutation.apply_slice(&vec[..]), vec!['a','b','c','d']);
     /// ```
     pub fn one(len: usize) -> Permutation {
         Permutation {
@@ -121,7 +222,7 @@ impl Permutation {
     /// ```
     /// use permutation::Permutation;
     /// let permutation = Permutation::one(4);
-    /// assert!(permutation.len() == 4);
+    /// assert_eq!(permutation.len(), 4);
     /// ```
     pub fn len(&self) -> usize {
         return self.indices.len();
@@ -146,7 +247,7 @@ impl Permutation {
     /// ```
     /// # use permutation::Permutation;
     /// let permutation = Permutation::from_vec(vec![0,2,3,1]);
-    /// assert!(permutation.inverse() == Permutation::from_vec(vec![0,3,1,2]));
+    /// assert_eq!(permutation.inverse(), Permutation::from_vec(vec![0,3,1,2]));
     /// ```
     pub fn inverse(mut self) -> Permutation {
         self.inv ^= true;
@@ -173,7 +274,7 @@ impl Permutation {
     /// # use permutation::Permutation;
     /// let permutation = Permutation::from_vec(vec![0, 3, 2, 5, 1, 4]);
     /// let reversed = permutation.inverse().normalize(true);
-    /// assert!(reversed.apply_inv_idx(3) == 1);
+    /// assert_eq!(reversed.apply_inv_idx(3), 1);
     /// ```
     pub fn normalize(self, backward: bool) -> Permutation {
         // Note that "reverse" index lookups are easier, so we actually
@@ -188,14 +289,10 @@ impl Permutation {
             } else {
                 (&self.inverse() * &Permutation::one(len)).inverse()
             }
-
         }
     }
     fn apply_idx_fwd(&self, idx: usize) -> usize {
-        self.indices
-            .iter()
-            .position(|&v| v == idx)
-            .unwrap()
+        self.indices.iter().position(|&v| v == idx).unwrap()
     }
     fn apply_idx_bkwd(&self, idx: usize) -> usize {
         self.indices[idx]
@@ -211,7 +308,7 @@ impl Permutation {
     /// ```
     /// # use permutation::Permutation;
     /// let permutation = Permutation::from_vec(vec![0,2,1]);
-    /// assert!(permutation.apply_idx(2) == 1);
+    /// assert_eq!(permutation.apply_idx(2), 1);
     pub fn apply_idx(&self, idx: usize) -> usize {
         match self.inv {
             false => self.apply_idx_fwd(idx),
@@ -231,7 +328,7 @@ impl Permutation {
     /// ```
     /// # use permutation::Permutation;
     /// let permutation = Permutation::from_vec(vec![0,2,1]);
-    /// assert!(permutation.apply_inv_idx(1) == 2);
+    /// assert_eq!(permutation.apply_inv_idx(1), 2);
     /// ```
     pub fn apply_inv_idx(&self, idx: usize) -> usize {
         match self.inv {
@@ -240,16 +337,15 @@ impl Permutation {
         }
     }
     fn apply_slice_fwd<T: Clone, D>(&self, vec: D) -> Vec<T>
-        where D: Deref<Target = [T]>
+    where
+        D: Deref<Target = [T]>,
     {
-        self.indices
-            .iter()
-            .map(|&idx| vec[idx].clone())
-            .collect()
+        self.indices.iter().map(|&idx| vec[idx].clone()).collect()
     }
 
     fn apply_slice_bkwd<T: Clone, D>(&self, vec: D) -> Vec<T>
-        where D: Deref<Target = [T]>
+    where
+        D: Deref<Target = [T]>,
     {
         let mut other: Vec<T> = vec.to_vec();
         for (i, idx) in self.indices.iter().enumerate() {
@@ -257,10 +353,11 @@ impl Permutation {
         }
         return other;
     }
+
     /// Apply a permutation to a slice of elements
     ///
-    /// Given a slice of elements, this will permute the elements in place according
-    /// to this permutation.
+    /// Given a slice of elements, this will permute the elements according
+    /// to this permutation and clone them to a `Vec`.
     ///
     /// # Examples
     ///
@@ -268,12 +365,14 @@ impl Permutation {
     /// # use permutation::Permutation;
     /// let permutation = Permutation::from_vec(vec![0,3,1,2]);
     /// let vec = vec!['a','b','c','d'];
-    /// assert!(permutation.apply_slice(&vec[..]) == vec!['a', 'd', 'b', 'c']);
+    /// assert_eq!(permutation.apply_slice(&vec[..]), vec!['a', 'd', 'b', 'c']);
     /// ```
+    #[must_use]
     pub fn apply_slice<T: Clone, D>(&self, vec: D) -> Vec<T>
-        where D: Deref<Target = [T]>
+    where
+        D: Deref<Target = [T]>,
     {
-        assert!(vec.len() == self.len());
+        assert_eq!(vec.len(), self.len());
         match self.inv {
             false => self.apply_slice_fwd(vec),
             true => self.apply_slice_bkwd(vec),
@@ -282,8 +381,9 @@ impl Permutation {
 
     /// Apply the inverse of a permutation to a slice of elements
     ///
-    /// Given a slice of elements, this will permute the elements in place according
-    /// to the inverse of this permutation.  This is equivalent to "undoing" the permutation.
+    /// Given a slice of elements, this will permute the elements according
+    /// to the inverse of this permutation and clone them to a `Vec`.
+    /// This is equivalent to "undoing" the permutation.
     ///
     /// # Examples
     ///
@@ -291,12 +391,14 @@ impl Permutation {
     /// # use permutation::Permutation;
     /// let permutation = Permutation::from_vec(vec![0,3,1,2]);
     /// let vec = vec!['a','b', 'c', 'd'];
-    /// assert!(permutation.apply_inv_slice(vec) == vec!['a', 'c', 'd', 'b']);
+    /// assert_eq!(permutation.apply_inv_slice(vec), vec!['a', 'c', 'd', 'b']);
     /// ```
+    #[must_use]
     pub fn apply_inv_slice<T: Clone, D>(&self, vec: D) -> Vec<T>
-        where D: Deref<Target = [T]>
+    where
+        D: Deref<Target = [T]>,
     {
-        assert!(vec.len() == self.len());
+        assert_eq!(vec.len(), self.len());
         match self.inv {
             false => self.apply_slice_bkwd(vec),
             true => self.apply_slice_fwd(vec),
@@ -316,7 +418,7 @@ impl Permutation {
 /// let permutation = permutation::sort(&vec[..]);
 /// let permuted = permutation.apply_slice(&vec[..]);
 /// vec.sort();
-/// assert!(vec == permuted);
+/// assert_eq!(vec, permuted);
 /// ```
 ///
 /// You can also use it to sort multiple arrays based on the ordering of one.
@@ -327,12 +429,13 @@ impl Permutation {
 /// let permutation = permutation::sort(&salary[..]);
 /// let ordered_names = permutation.apply_slice(&names[..]);
 /// let ordered_salaries = permutation.apply_slice(&salary[..]);
-/// assert!(ordered_names == vec!["Steve", "Bob", "Jane"]);
-/// assert!(ordered_salaries == vec![5, 10, 15]);
+/// assert_eq!(ordered_names, vec!["Steve", "Bob", "Jane"]);
+/// assert_eq!(ordered_salaries, vec![5, 10, 15]);
 /// ```
 pub fn sort<T, D>(vec: D) -> Permutation
-    where T: Ord,
-          D: Deref<Target = [T]>
+where
+    T: Ord,
+    D: Deref<Target = [T]>,
 {
     let mut permutation = Permutation::one(vec.len());
     //We use the reverse permutation form, because its more efficient for applying to indices.
@@ -353,16 +456,19 @@ pub fn sort<T, D>(vec: D) -> Permutation
 /// let permutation = permutation::sort_by(&vec[..], |a, b| b.cmp(a));
 /// let permuted = permutation.apply_slice(&vec[..]);
 /// vec.sort_by(|a,b| b.cmp(a));
-/// assert!(vec == permuted);
+/// assert_eq!(vec, permuted);
 /// ```
 pub fn sort_by<T, D, F>(vec: D, mut compare: F) -> Permutation
-    where T: Ord,
-          D: Deref<Target = [T]>,
-          F: FnMut(&T, &T) -> Ordering
+where
+    T: Ord,
+    D: Deref<Target = [T]>,
+    F: FnMut(&T, &T) -> Ordering,
 {
     let mut permutation = Permutation::one(vec.len());
     //We use the reverse permutation form, because its more efficient for applying to indices.
-    permutation.indices.sort_by(|&i, &j| compare(&vec[i], &vec[j]));
+    permutation
+        .indices
+        .sort_by(|&i, &j| compare(&vec[i], &vec[j]));
     return permutation;
 }
 
@@ -379,12 +485,13 @@ pub fn sort_by<T, D, F>(vec: D, mut compare: F) -> Permutation
 /// let permutation = permutation::sort_by_key(&vec[..], |a| a % 3);
 /// let permuted = permutation.apply_slice(&vec[..]);
 /// vec.sort_by_key(|a| a % 3);
-/// assert!(vec == permuted);
+/// assert_eq!(vec, permuted);
 /// ```
 pub fn sort_by_key<T, D, B, F>(vec: D, mut f: F) -> Permutation
-    where B: Ord,
-          D: Deref<Target = [T]>,
-          F: FnMut(&T) -> B
+where
+    B: Ord,
+    D: Deref<Target = [T]>,
+    F: FnMut(&T) -> B,
 {
     let mut permutation = Permutation::one(vec.len());
     //We use the reverse permutation form, because its more efficient for applying to indices.
@@ -402,12 +509,12 @@ mod tests {
         let p1 = Permutation::one(5);
         let p2 = Permutation::one(5);
         assert!(p1.valid());
-        assert!(p1 == p2);
+        assert_eq!(p1, p2);
         let p3 = Permutation::one(6);
         assert!(p1 != p3);
 
-        assert!(&p1 * &p2 == p1);
-        assert!(p1.clone().inverse() == p1);
+        assert_eq!(&p1 * &p2, p1);
+        assert_eq!(p1.clone().inverse(), p1);
     }
 
     #[test]
@@ -415,28 +522,28 @@ mod tests {
         let id = Permutation::one(3);
         let p1 = Permutation::from_vec(vec![1, 0, 2]);
         let square = &p1 * &p1;
-        assert!(square == id);
+        assert_eq!(square, id);
         let cube = &p1 * &square;
-        assert!(cube == p1);
+        assert_eq!(cube, p1);
     }
     #[test]
     fn prod() {
         let p1 = Permutation::from_vec(vec![1, 0, 2]);
         let p2 = Permutation::from_vec(vec![0, 2, 1]);
         let prod = &p1 * &p2;
-        assert!(prod == Permutation::from_vec(vec![2, 0, 1]));
+        assert_eq!(prod, Permutation::from_vec(vec![2, 0, 1]));
     }
     #[test]
     fn len() {
         let p1 = Permutation::from_vec(vec![1, 0, 2]);
-        assert!(p1.len() == 3)
+        assert_eq!(p1.len(), 3)
     }
     fn check_not_equal_inverses(p2: &Permutation, p3: &Permutation) {
         assert!(*p2 != *p3);
-        assert!(p2 * p3 == Permutation::one(p2.len()));
-        assert!(p3 * p2 == Permutation::one(p2.len()));
-        assert!(*p2 == p3.clone().inverse());
-        assert!(p2.clone().inverse() == *p3);
+        assert_eq!(p2 * p3, Permutation::one(p2.len()));
+        assert_eq!(p3 * p2, Permutation::one(p2.len()));
+        assert_eq!(*p2, p3.clone().inverse());
+        assert_eq!(p2.clone().inverse(), *p3);
         assert!(p2.clone().inverse() != p3.clone().inverse());
         assert!(p2 * &p3.clone().inverse() != Permutation::one(p2.len()));
         assert!(&p2.clone().inverse() * p3 != Permutation::one(p2.len()));
@@ -445,18 +552,23 @@ mod tests {
     fn inverse() {
         let p1 = Permutation::from_vec(vec![1, 0, 2]);
         let rev = p1.clone().inverse();
-        assert!(p1 == rev);
+        assert_eq!(p1, rev);
 
         //An element and its inverse
         let p2 = Permutation::from_vec(vec![1, 2, 0, 4, 3]);
         let p3 = Permutation::from_vec(vec![2, 0, 1, 4, 3]);
 
         check_not_equal_inverses(&p2, &p3);
-        println!("{:?}, {:?}, {:?}",
-                 p2.clone().inverse(),
-                 p3.clone().inverse(),
-                 &p2.clone().inverse() * &p3.clone().inverse());
-        assert!(&p2.clone().inverse() * &p3.clone().inverse() == Permutation::one(p2.len()));
+        println!(
+            "{:?}, {:?}, {:?}",
+            p2.clone().inverse(),
+            p3.clone().inverse(),
+            &p2.clone().inverse() * &p3.clone().inverse()
+        );
+        assert_eq!(
+            &p2.clone().inverse() * &p3.clone().inverse(),
+            Permutation::one(p2.len())
+        );
 
         //An element, and a distinct element which is not its inverse.
         let p4 = Permutation::from_vec(vec![1, 2, 0, 3, 4]);
@@ -477,36 +589,39 @@ mod tests {
         let elems = vec!['a', 'b', 'e', 'g', 'f'];
         let perm = permutation::sort(&elems[..]);
         println!("{:?}", perm);
-        assert!(perm == Permutation::from_vec(vec![0, 1, 2, 4, 3]));
+        assert_eq!(perm, Permutation::from_vec(vec![0, 1, 2, 4, 3]));
     }
     #[test]
     fn strings() {
         let elems = vec!["doggie", "cat", "doggo", "dog", "doggies", "god"];
         let perm = permutation::sort(&elems[..]);
-        assert!(perm == Permutation::from_vec(vec![1, 3, 0, 4, 2, 5]));
+        assert_eq!(perm, Permutation::from_vec(vec![1, 3, 0, 4, 2, 5]));
 
-        assert!(perm.apply_slice(&elems[..]) ==
-                vec!["cat", "dog", "doggie", "doggies", "doggo", "god"]);
+        assert!(
+            perm.apply_slice(&elems[..]) == vec!["cat", "dog", "doggie", "doggies", "doggo", "god"]
+        );
         let parallel = vec!["doggie1", "cat1", "doggo1", "dog1", "doggies1", "god1"];
         let par_permuted = perm.apply_slice(&parallel[..]);
         println!("{:?}", par_permuted);
-        assert!(par_permuted == vec!["cat1", "dog1", "doggie1", "doggies1", "doggo1", "god1"]);
-        assert!(perm.apply_inv_slice(par_permuted) == parallel);
+        assert_eq!(
+            par_permuted,
+            vec!["cat1", "dog1", "doggie1", "doggies1", "doggo1", "god1"]
+        );
+        assert_eq!(perm.apply_inv_slice(par_permuted), parallel);
     }
-
 
     #[test]
     fn by_key() {
         let vec = vec![1, 10, 9, 8];
         let perm = permutation::sort_by_key(vec, |i| -i);
-        assert!(perm == Permutation::from_vec(vec![1, 2, 3, 0]));
+        assert_eq!(perm, Permutation::from_vec(vec![1, 2, 3, 0]));
     }
 
     #[test]
     fn by_cmp() {
         let vec = vec!["aaabaab", "aba", "cas", "aaab"];
         let perm = permutation::sort_by(vec, |a, b| a.cmp(b));
-        assert!(perm == Permutation::from_vec(vec![3, 0, 1, 2]));
+        assert_eq!(perm, Permutation::from_vec(vec![3, 0, 1, 2]));
     }
 
     #[test]
@@ -514,17 +629,17 @@ mod tests {
         let vec = vec![100, 10, 1, 1000];
         let perm = permutation::sort_by_key(vec, |x| -x);
         println!("{:?}", perm.apply_inv_idx(0));
-        assert!(perm.apply_inv_idx(0) == 3);
-        assert!(perm.apply_idx(3) == 0);
+        assert_eq!(perm.apply_inv_idx(0), 3);
+        assert_eq!(perm.apply_idx(3), 0);
 
-        assert!(perm.apply_inv_idx(1) == 0);
-        assert!(perm.apply_idx(0) == 1);
+        assert_eq!(perm.apply_inv_idx(1), 0);
+        assert_eq!(perm.apply_idx(0), 1);
 
-        assert!(perm.apply_inv_idx(2) == 1);
-        assert!(perm.apply_idx(1) == 2);
+        assert_eq!(perm.apply_inv_idx(2), 1);
+        assert_eq!(perm.apply_idx(1), 2);
 
-        assert!(perm.apply_inv_idx(3) == 2);
-        assert!(perm.apply_idx(2) == 3);
+        assert_eq!(perm.apply_inv_idx(3), 2);
+        assert_eq!(perm.apply_idx(2), 3);
     }
     #[test]
     fn normalize() {
@@ -532,31 +647,31 @@ mod tests {
         let perm = permutation::sort_by_key(vec, |x| -x);
         let f = perm.clone().normalize(false);
         let b = perm.clone().normalize(true);
-        assert!(perm == f);
-        assert!(f == b);
+        assert_eq!(perm, f);
+        assert_eq!(f, b);
         for idx in 0..perm.len() {
-            assert!(perm.apply_idx(idx) == f.apply_idx(idx));
-            assert!(f.apply_idx(idx) == b.apply_idx(idx));
-            assert!(perm.apply_inv_idx(idx) == f.apply_inv_idx(idx));
-            assert!(f.apply_inv_idx(idx) == b.apply_inv_idx(idx));
+            assert_eq!(perm.apply_idx(idx), f.apply_idx(idx));
+            assert_eq!(f.apply_idx(idx), b.apply_idx(idx));
+            assert_eq!(perm.apply_inv_idx(idx), f.apply_inv_idx(idx));
+            assert_eq!(f.apply_inv_idx(idx), b.apply_inv_idx(idx));
         }
         let inv = perm.clone().inverse();
         let fi = inv.clone().normalize(false);
         let bi = inv.clone().normalize(true);
-        assert!(inv == fi);
-        assert!(fi == bi);
+        assert_eq!(inv, fi);
+        assert_eq!(fi, bi);
         for idx in 0..perm.len() {
-            assert!(inv.apply_idx(idx) == fi.apply_idx(idx));
-            assert!(fi.apply_idx(idx) == bi.apply_idx(idx));
-            assert!(inv.apply_inv_idx(idx) == fi.apply_inv_idx(idx));
-            assert!(fi.apply_inv_idx(idx) == bi.apply_inv_idx(idx));
+            assert_eq!(inv.apply_idx(idx), fi.apply_idx(idx));
+            assert_eq!(fi.apply_idx(idx), bi.apply_idx(idx));
+            assert_eq!(inv.apply_inv_idx(idx), fi.apply_inv_idx(idx));
+            assert_eq!(fi.apply_inv_idx(idx), bi.apply_inv_idx(idx));
         }
     }
     #[test]
     fn normalize_inv() {
         let p1 = Permutation::from_vec(vec![1, 0, 2]);
         let rev = p1.clone().inverse();
-        assert!(p1 == rev);
+        assert_eq!(p1, rev);
 
         //An element and its inverse
         let mut p2 = Permutation::from_vec(vec![1, 2, 0, 4, 3]);

--- a/src/permutation.rs
+++ b/src/permutation.rs
@@ -95,8 +95,8 @@ impl Permutation {
     }
     /// Computes the permutation that would sort a given slice.
     ///
-    /// This calculates the permutation that if it were applied to the slice,
-    /// would put the elements in sorted order.
+    /// This is the same as `permutation::sort()`, but assigned in-place to `self` rather than
+    /// allocating a new permutation.
     ///
     /// # Panics
     ///
@@ -106,27 +106,26 @@ impl Permutation {
     ///
     /// ```
     /// # use permutation::Permutation;
-    /// let mut vec = vec!['z','w','h','a','s','j'];
-    /// let mut permutation = permutation::Permutation::one(vec.len());
-    /// permutation.sort(&vec[..]);
+    /// // Say you have a permutation that we don't need anymore...
+    /// let mut permutation = permutation::sort(&[0,1,2][..]);
+    ///
+    /// // You can reuse it rather than allocating a new one, as long as the length is the same
+    /// let mut vec = vec!['z','w','h'];
+    /// permutation.assign_from_sort(&vec[..]);
     /// let permuted = permutation.apply_slice(&vec[..]);
     /// vec.sort();
     /// assert_eq!(vec, permuted);
-    /// ```
     ///
-    /// You can also use it to sort multiple arrays based on the ordering of one.
-    ///
-    /// ```
+    /// // You can also use it to sort multiple arrays based on the ordering of one.
     /// let names = vec!["Bob", "Steve", "Jane"];
     /// let salary = vec![10, 5, 15];
-    /// let mut permutation = permutation::Permutation::one(salary.len());
-    /// permutation.sort(&salary[..]);
+    /// permutation.assign_from_sort(&salary[..]);
     /// let ordered_names = permutation.apply_slice(&names[..]);
     /// let ordered_salaries = permutation.apply_slice(&salary[..]);
     /// assert_eq!(ordered_names, vec!["Steve", "Bob", "Jane"]);
     /// assert_eq!(ordered_salaries, vec![5, 10, 15]);
     /// ```
-    pub fn sort<T, D>(&mut self, vec: D)
+    pub fn assign_from_sort<T, D>(&mut self, vec: D)
     where
         T: Ord,
         D: Deref<Target = [T]>,
@@ -138,8 +137,8 @@ impl Permutation {
 
     /// Computes the permutation that would sort a given slice by a comparator.
     ///
-    /// This is the same as `permutation::sort()` except that it allows you to specify
-    /// the comparator to use when sorting similar to `std::slice.sort_by()`
+    /// This is the same as `permutation::sort_by()`, but assigned in-place to `self` rather than
+    /// allocating a new permutation.
     ///
     /// # Panics
     ///
@@ -149,14 +148,17 @@ impl Permutation {
     ///
     /// ```
     /// # use permutation::Permutation;
+    /// // Say you have a permutation that we don't need anymore...
+    /// let mut permutation = permutation::sort(&[0,1,2,3,4,5][..]);
+    ///
+    /// // You can assign to it rather than allocating a new one, as long as the length is the same
     /// let mut vec = vec!['z','w','h','a','s','j'];
-    /// let mut permutation = permutation::Permutation::one(vec.len());
-    /// permutation.sort_by(&vec[..], |a, b| b.cmp(a));
+    /// permutation.assign_from_sort_by(&vec[..], |a, b| b.cmp(a));
     /// let permuted = permutation.apply_slice(&vec[..]);
     /// vec.sort_by(|a,b| b.cmp(a));
     /// assert_eq!(vec, permuted);
     /// ```
-    pub fn sort_by<T, D, F>(&mut self, vec: D, mut compare: F)
+    pub fn assign_from_sort_by<T, D, F>(&mut self, vec: D, mut compare: F)
     where
         T: Ord,
         D: Deref<Target = [T]>,
@@ -169,8 +171,8 @@ impl Permutation {
 
     /// Computes the permutation that would sort a given slice by a key function.
     ///
-    /// This is the same as `permutation::sort()` except that it allows you to specify
-    /// the key function simliar to `std::slice.sort_by_key()`
+    /// This is the same as `permutation::sort_by_key()`, but assigned in-place to `self` rather than
+    /// allocating a new permutation.
     ///
     /// # Panics
     ///
@@ -180,14 +182,17 @@ impl Permutation {
     ///
     /// ```
     /// # use permutation::Permutation;
+    /// // Say you have a permutation that we don't need anymore...
+    /// let mut permutation = permutation::sort(&[0,1,2,3,4,5][..]);
+    ///
+    /// // You can assign to it rather than allocating a new one, as long as the length is the same
     /// let mut vec = vec![2, 4, 6, 8, 10, 11];
-    /// let mut permutation = permutation::Permutation::one(vec.len());
-    /// permutation.sort_by_key(&vec[..], |a| a % 3);
+    /// permutation.assign_from_sort_by_key(&vec[..], |a| a % 3);
     /// let permuted = permutation.apply_slice(&vec[..]);
     /// vec.sort_by_key(|a| a % 3);
     /// assert_eq!(vec, permuted);
     /// ```
-    pub fn sort_by_key<T, D, B, F>(&mut self, vec: D, mut f: F)
+    pub fn assign_from_sort_by_key<T, D, B, F>(&mut self, vec: D, mut f: F)
     where
         B: Ord,
         D: Deref<Target = [T]>,

--- a/src/permutation.rs
+++ b/src/permutation.rs
@@ -368,7 +368,7 @@ impl Permutation {
         (idx & (isize::min_value() as usize)) != 0
     }
 
-    fn apply_slice_fwd_in_place<T>(&mut self, slice: &mut [T]) {
+    fn apply_slice_bkwd_in_place<T>(&mut self, slice: &mut [T]) {
         for idx in self.indices.iter() {
             assert!(!Self::idx_is_marked(*idx));
         }
@@ -489,7 +489,7 @@ impl Permutation {
     pub fn apply_slice_in_place<T>(&mut self, slice: &mut [T]) {
         assert_eq!(slice.len(), self.len());
         match self.inv {
-            false => self.apply_slice_fwd_in_place(slice),
+            false => self.apply_slice_bkwd_in_place(slice),
             true => panic!("Permutation not normalized for backward application"),
         }
     }
@@ -524,7 +524,7 @@ impl Permutation {
 
         match self.inv {
             false => panic!("Permutation not normalized for forward application"),
-            true => self.apply_slice_fwd_in_place(slice),
+            true => self.apply_slice_bkwd_in_place(slice),
         }
     }
 }


### PR DESCRIPTION
- Corrects the documentation and adds `#[must_use]` to `apply_slice` and `apply_slice_inv`
- Adds `apply_slice_in_place` and `apply_slice_inv_in_place`

The documentation for `apply_slice` and `apply_slice_inv` claim that the slice is modified in-place, when in fact it's not modified and the permuted output is returned as a fresh `Vec`. I realized only after hunting down some tricky bugs where nothing was being permuted, and I was especially surprised since the compiler should emit warnings for discarding the result of an operation without side effects.

My implementation of the in-place versions currently only works if the permutation is normalized in the opposite direction compared to the rest of the class, and panics otherwise.

I also only just realized that the diff is inflated by rustfmt and my replacement of `assert` with `assert_eq` affecting more than just my code, I can split those changes into a different PR if that'd be better.