### PR TITLE
Removed Ord trait from sort_by

### DIFF
--- a/src/permutation.rs
+++ b/src/permutation.rs
@@ -356,8 +356,7 @@ pub fn sort<T, D>(vec: D) -> Permutation
 /// assert!(vec == permuted);
 /// ```
 pub fn sort_by<T, D, F>(vec: D, mut compare: F) -> Permutation
-    where T: Ord,
-          D: Deref<Target = [T]>,
+    where D: Deref<Target = [T]>,
           F: FnMut(&T, &T) -> Ordering
 {
     let mut permutation = Permutation::one(vec.len());
@@ -507,6 +506,13 @@ mod tests {
         let vec = vec!["aaabaab", "aba", "cas", "aaab"];
         let perm = permutation::sort_by(vec, |a, b| a.cmp(b));
         assert!(perm == Permutation::from_vec(vec![3, 0, 1, 2]));
+    }
+
+    #[test]
+    fn by_partially_ordered_cmp() {
+        let vec = vec![1.0, 5.0, 3.0, 2.0, 8.0];
+        let perm = permutation::sort_by(vec, |a, b| a.partial_cmp(b).unwrap());
+        assert!(perm == Permutation::from_vec(vec![0, 3, 2, 1, 4]));
     }
 
     #[test]


### PR DESCRIPTION
Hi there, this change is to remove the Ord trait from the sort_by function. I believe that this can be removed as the type of the vector to be sorted doesn't need to be totally ordered in order to sort by a comparator as a total order can be defined on a partially ordered (or even an unordered) type for a given situation by a proper comparator. This is the same reason why the standard library doesn't require the vector type be ordered for the slice::sort_by function. In the event that the function is not totally order, the behavior of the function simply becomes undefined. I've also added a test to make sure that the function works as intended. 

I'm relatively new to rust so if there's some deeper reason that this sort_by requires an ordering and I'm just missing it, please let me know.