### PR TITLE
Finish PR by @SeanPrendi

### DIFF
--- a/src/permutation.rs
+++ b/src/permutation.rs
@@ -356,8 +356,7 @@ pub fn sort<T, D>(vec: D) -> Permutation
 /// assert!(vec == permuted);
 /// ```
 pub fn sort_by<T, D, F>(vec: D, mut compare: F) -> Permutation
-    where T: Ord,
-          D: Deref<Target = [T]>,
+    where D: Deref<Target = [T]>,
           F: FnMut(&T, &T) -> Ordering
 {
     let mut permutation = Permutation::one(vec.len());
@@ -507,6 +506,13 @@ mod tests {
         let vec = vec!["aaabaab", "aba", "cas", "aaab"];
         let perm = permutation::sort_by(vec, |a, b| a.cmp(b));
         assert!(perm == Permutation::from_vec(vec![3, 0, 1, 2]));
+    }
+
+    #[test]
+    fn by_partially_ordered_cmp() {
+        let vec = vec![1.0, 5.0, 3.0, 2.0, 8.0];
+        let perm = permutation::sort_by(vec, |a, b| a.partial_cmp(b).unwrap());
+        assert!(perm == Permutation::from_vec(vec![0, 3, 2, 1, 4]));
     }
 
     #[test]

--- a/src/permutation.rs
+++ b/src/permutation.rs
@@ -343,7 +343,14 @@ pub fn sort<T, D>(vec: D) -> Permutation
 /// Return the permutation that would sort a given slice by a comparator.
 ///
 /// This is the same as `permutation::sort()` except that it allows you to specify
-/// the comparator to use when sorting similar to `std::slice.sort_by()`
+/// the comparator to use when sorting similar to `std::slice.sort_by()`.
+///
+/// If the comparator does not define a total ordering, the order of the elements is unspecified.
+/// Per the [Rust Docs](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.sort_by),
+/// an order is a total order if it is (for all `a`, `b` and `c`):
+///
+/// * total and antisymmetric: exactly one of `a < b`, `a == b` or `a > b` is true, and
+/// * transitive, `a < b` and `b < c` implies `a < c`. The same must hold for both `==` and `>`.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
I ran into the problem with sort_by requiring T to be Ord while using the library, and noticed that there was already a PR to fix this, but it hadn't been merged.

I added some extra docs explaining that the ordering is unspecified if the comparator doesn't define a total ordering to hopefully get that change merged.